### PR TITLE
CxPilot 5.0.0 Release (Internal Release)

### DIFF
--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,14 +1,14 @@
-Release 5.0.0-beta3 21st Dec 2023
+Release 5.0.0 23rd Jan 2024
 ------------------------------
- - Updated default CarbonixCubeOrange Param
-
-Release 5.0.0-beta2 15th Dec 2023
-------------------------------
+ - workflow: Added cx_build_compare CI for Carbonix board for build compare, triggered on Label CX_NO_CODE_CHANGE
+ - workflow: modified Carbonix build script to add CARBOPILOT=1  
+ - hwdef: Modified Carbonix boards to remove AP_CUSTOM_FIRMWARE
+ - AP_FWVersion: Added Custom Firmware Location to one define in AP_FWVersionDefine.h 
+ - Tools: Added Carbonix build no clean script
+ - Parameter Docs modified to make CarboParam working 
+ - Hwdef: Updated default CarbonixCubeOrange Param
  - AP_Periph: fix arm_update_status missing update
  - HWDEF : carbonix default params cleanup
-
-Release 5.0.0-beta1 28th Nov 2023
-------------------------------
  - AP_Periph: print version name
  - CI: Carbonix build script added
  - Tools: rebuild Carbonix Custom Board bootloaders

--- a/libraries/AP_Common/AP_FWVersionDefine.h
+++ b/libraries/AP_Common/AP_FWVersionDefine.h
@@ -24,7 +24,7 @@
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
 #ifdef CARBOPILOT
-#define AP_CUSTOM_FIRMWARE_STRING "CarboPilot V5.0.0-beta3"
+#define AP_CUSTOM_FIRMWARE_STRING "CxPilot V5.0.0"
 #endif
 
 /*


### PR DESCRIPTION
Also modified the naming convention of firmware from CarboPilot to CxPilot

SW-73

Release getting Prepared.

This Firmware has done flights on Volanti and Ottano till the point of beta3 after which the changes where non code.
It is still pending to finish complete testing but we have started moving towards 5.1.0 so we are making this internal release.