### PR TITLE
Feature/sw 116 lua quick tune update limit gain change

### DIFF
--- a/libraries/AP_Scripting/applets/VTOL-quicktune.lua
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.lua
@@ -183,6 +183,7 @@ end
 -- setup filter frequencies
 function setup_filters(axis)
    if QUIK_AUTO_FILTER:get() <= 0 then
+      filters_done[axis] = true
       return
    end
    local fltd = axis .. "_FLTD"


### PR DESCRIPTION
This is a bug fix for VTOL-quicktune and also a feature addition to get the QUIK_MAX_REDUCE included into our quiktune and make sure that it will still work on our build. 

It is tested on SITL and will try to get it tested on Aircraft.