### PR TITLE
AP_ICEngine: don't allow engine run with safety on

### DIFF
--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -355,7 +355,12 @@ void AP_ICEngine::update(void)
 
     case ICE_STARTING:
         set_ignition(true);
-        set_starter(true);
+
+        if (allow_throttle_disarmed()) {
+            set_starter(true);
+        } else {
+            set_starter(false);
+        }
 
         if (starter_start_time_ms == 0) {
             starter_start_time_ms = now;
@@ -544,6 +549,15 @@ void AP_ICEngine::update_idle_governor(int8_t &min_throttle)
     idle_governor_integrator = constrain_float(idle_governor_integrator, min_throttle_base, 40.0f);
 
     min_throttle = roundf(idle_governor_integrator);
+}
+
+/*
+  Allows throttle when disarmed and Safety Switch is not ON
+ */
+bool AP_ICEngine::allow_throttle_disarmed() const
+{
+    return option_set(Options::THROTTLE_WHILE_DISARMED) &&
+        hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_DISARMED;
 }
 
 /*

--- a/libraries/AP_ICEngine/AP_ICEngine.h
+++ b/libraries/AP_ICEngine/AP_ICEngine.h
@@ -64,6 +64,8 @@ public:
 
     static AP_ICEngine *get_singleton() { return _singleton; }
 
+    bool allow_throttle_disarmed() const;
+
 private:
     static AP_ICEngine *_singleton;
 


### PR DESCRIPTION
Cherry-pick source:
 - AP_ICEngine: don't allow engine run with safety on : e0708489ad04a7d1fd402dc6273a51e377da7f32
 - AP_EFI: fixed ignition while disarmed : 29568105fbbe82d0e6e16a7596f7de4b75283f79

Cherry-pick was not sufficient, since the code has changed since 4.3.25. This code is tested after changes.