### PR TITLE
LUA :  added bindings for extended ESC telem

### DIFF
--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1245,9 +1245,27 @@ function esc_telem:update_rpm(esc_index, rpm, error_rate) end
 function esc_telem:set_rpm_scale(esc_index, scale_factor) end
 
 -- get the timestamp of last telemetry data for an ESC
----@param esc_index integer
+---@param instance integer (0 is first motor)
 ---@return uint32_t_ud
-function esc_telem:get_last_telem_data_ms(esc_index) end
+function esc_telem:get_last_telem_data_ms(instance) end
+
+-- get the input_duty of last telemetry data for an ESC
+---@param instance integer (0 is first motor)
+---@param input_duty integer
+---@return boolean
+function esc_telem:get_input_duty(instance, input_duty) end
+
+-- get the output_duty of last telemetry data for an ESC
+---@param instance integer (0 is first motor)
+---@param output_duty integer
+---@return boolean
+function esc_telem:get_output_duty(instance, output_duty) end
+
+-- get the status flags of the last telemetry data for an ESC
+---@param instance integer (0 is first motor)
+---@param flags integer
+---@return boolean
+function esc_telem:get_flags(instance, flags) end
 
 -- desc
 ---@class optical_flow

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -315,6 +315,9 @@ singleton AP_ESC_Telem method get_usage_seconds boolean uint8_t 0 NUM_SERVO_CHAN
 singleton AP_ESC_Telem method update_rpm void uint8_t 0 NUM_SERVO_CHANNELS uint16_t'skip_check float'skip_check
 singleton AP_ESC_Telem method set_rpm_scale void uint8_t 0 NUM_SERVO_CHANNELS float'skip_check
 singleton AP_ESC_Telem method get_last_telem_data_ms uint32_t uint8_t 0 NUM_SERVO_CHANNELS
+singleton AP_ESC_Telem method get_input_duty boolean uint8_t 0 NUM_SERVO_CHANNELS uint8_t'Null
+singleton AP_ESC_Telem method get_output_duty boolean uint8_t 0 NUM_SERVO_CHANNELS uint8_t'Null
+singleton AP_ESC_Telem method get_flags boolean uint8_t 0 NUM_SERVO_CHANNELS uint32_t'Null
 
 include AP_Param/AP_Param.h
 singleton AP_Param rename param


### PR DESCRIPTION
Added lua bindings for the following : 

`singleton AP_ESC_Telem method get_input_duty boolean uint8_t 0 NUM_SERVO_CHANNELS uint8_t'Null`
`singleton AP_ESC_Telem method get_output_duty boolean uint8_t 0 NUM_SERVO_CHANNELS uint8_t'Null`
`singleton AP_ESC_Telem method get_flags boolean uint8_t 0 NUM_SERVO_CHANNELS uint32_t'Null`