### PR TITLE
AP_Param: fixed setting of defaults for dynamic param trees

### DIFF
--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -603,6 +603,11 @@ private:
     static uint16_t             _frame_type_flags;
 
     /*
+      this is true if when scanning a defaults file we find all of the parameters
+     */
+    static bool done_all_default_params;
+
+    /*
       structure for built-in defaults file that can be modified using apj_tool.py
      */
 #if AP_PARAM_MAX_EMBEDDED_PARAM > 0


### PR DESCRIPTION
when we load a VARPTR subtree we need to re-scan the parameter
defaults file from @ROMFS/defaults.parm in case there are defaults
applicable to this subtree

SW-248