### PR TITLE
EFI : correct hirth EFI log messages

### DIFF
--- a/libraries/AP_EFI/AP_EFI.cpp
+++ b/libraries/AP_EFI/AP_EFI.cpp
@@ -240,7 +240,7 @@ void AP_EFI::log_status(void)
                                 "TimeUS,Inst,IgnT,InjT,CHT,EGT,Lambda,CHT2,EGT2,IDX",
                                 "s#dsOO-OO-",
                                 "F-0C000000",
-                                "QBfffffBff",
+                                "QBffffffff",
                                 AP_HAL::micros64(),
                                 0,
                                 state.cylinder_status.ignition_timing_deg,

--- a/libraries/AP_EFI/AP_EFI_Serial_Hirth.cpp
+++ b/libraries/AP_EFI/AP_EFI_Serial_Hirth.cpp
@@ -300,7 +300,7 @@ void AP_EFI_Serial_Hirth::decode_data()
 
         // EFI2 log
         internal_state.engine_state = (Engine_State)record1->engine_status;
-        internal_state.crankshaft_sensor_status = (record1->sensor_ok & CRANK_SHAFT_SENSOR_OK) ? Crankshaft_Sensor_Status::OK : Crankshaft_Sensor_Status::ERROR;
+        internal_state.crankshaft_sensor_status = (record1->sensor_ok == CRANK_SHAFT_SENSOR_OK) ? Crankshaft_Sensor_Status::OK : Crankshaft_Sensor_Status::ERROR;
 
         // ECYL log
         internal_state.cylinder_status.injection_time_ms = record1->injection_time * INJECTION_TIME_RESOLUTION;


### PR DESCRIPTION
1. ECYL - state.cylinder_status.exhaust_gas_temperature2, format changed from B(uint8_t) to f(float)
2. Sensor_ok - showing OK, when engine_temperature_sensor_status = 0