### PR TITLE
Tools : Squash all build support tools commits

### DIFF
--- a/Tools/Carbonix_scripts/devid-decode.py
+++ b/Tools/Carbonix_scripts/devid-decode.py
@@ -1,0 +1,27 @@
+# Decode an ArduPilot device id
+
+import argparse
+
+parser = argparse.ArgumentParser(description='Decode a device id')
+parser.add_argument('device_id', type=int, help='Device ID to decode')
+args = parser.parse_args()
+
+bus_types = {
+    0: 'UNKNOWN',
+    1: 'I2C',
+    2: 'SPI',
+    3: 'UAVCAN',
+    4: 'SITL',
+    5: 'MSP',
+    6: 'SERIAL',
+    7: 'QSPI',
+}
+
+device_id = args.device_id
+bus_type = device_id & 0x7
+bus = (device_id >> 3) & 0x1f
+address = (device_id >> 8) & 0xff
+devtype = (device_id >> 16) & 0xff
+
+print(f"Device ID: {device_id}")
+print(f"{bus_types[bus_type]}{bus}, address {address}, devtype {devtype}")

--- a/Tools/Carbonix_scripts/devid-encode.py
+++ b/Tools/Carbonix_scripts/devid-encode.py
@@ -1,0 +1,21 @@
+# Encode an ArduPilot device ID
+
+# prompt the user for the bus type
+print("Bus types:")
+print("0: UNKNOWN")
+print("1: I2C")
+print("2: SPI")
+print("3: UAVCAN")
+print("4: SITL")
+print("5: MSP")
+print("6: SERIAL")
+print("7: QSPI")
+bus_type = int(input("Enter the bus type (0-7): "))
+
+# prompt the user for the bus number
+bus = int(input("Enter the bus number (0-31): "))
+address = int(input("Enter the address (0-255): "))
+devtype = int(input("Enter the device type (0-255): "))
+device_id = bus_type | (bus << 3) | (address << 8) | (devtype << 16)
+
+print(f"Device ID: {device_id}")

--- a/Tools/Carbonix_scripts/process_sitl_defaults.py
+++ b/Tools/Carbonix_scripts/process_sitl_defaults.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+'''
+Build SITL default parameter files for use with SITL launcher
+'''
+
+import os
+import re
+import fnmatch
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Build SITL default parameter files')
+    parser.add_argument('input_file', help='Input file to process')
+    parser.add_argument('output_file', help='Output file to write to')
+    args = parser.parse_args()
+
+    defaults = process_defaults(args.input_file)
+    with open(args.output_file, "w") as f:
+        f.write("\n".join(defaults))
+
+
+def process_defaults(file, depth=0):
+    if depth > 10:
+        raise Exception("Too many levels of @include")
+
+    param_list = []
+    with open(file, "r") as f:
+        lines = f.read().splitlines()
+    for line in lines:
+        if line.startswith("@include"):
+            rel_path = line.split(maxsplit=1)[1]
+            path = os.path.join(os.path.dirname(file), rel_path)
+            param_list.extend(
+                process_defaults(path, depth + 1)
+            )
+            continue
+
+        if line.startswith("@delete"):
+            pattern = line.split(maxsplit=1)[1]
+            for i in range(len(param_list)):
+                param_name = re.split(r"[\s,]+", param_list[i])[0]
+                if fnmatch.fnmatch(param_name, pattern):
+                    param_list[i] = "#deleted " + param_list[i]
+            line = "#" + line
+
+        param_list.append(line)
+
+    return param_list
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -590,15 +590,13 @@ def get_ap_periph_boards():
                     list_ap.append(d)
                     continue
                 # process any include lines:
-                m = re.match(r"include\s+([^\s]*)", content)
-                if m is None:
-                    continue
-                include_path = os.path.join(os.path.dirname(hwdef), m.group(1))
-                with open(include_path, "r") as g:
-                    content = g.read()
-                    if 'AP_PERIPH' in content:
-                        list_ap.append(d)
-                        continue
+                for m in re.finditer(r"^include\s+([^\s]*)", content, re.MULTILINE):
+                    include_path = os.path.join(os.path.dirname(hwdef), m.group(1))
+                    with open(include_path, "r") as g:
+                        content = g.read()
+                        if 'AP_PERIPH' in content:
+                            list_ap.append(d)
+                            break
 
     list_ap = list(set(list_ap))
     return list_ap

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1101,7 +1101,7 @@ class ChibiOSHWDef(object):
             f.write('#define APP_START_OFFSET_KB %u\n' % self.get_config('APP_START_OFFSET_KB', default=0, type=int))
         f.write('\n')
 
-        ram_reserve_start,ram0_start_address = self.get_ram_reserve_start()
+        ram_reserve_start, ram0_start_address = self.get_ram_reserve_start()
         f.write('#define HAL_RAM0_START 0x%08x\n' % ram0_start_address)
         if ram_reserve_start > 0:
             f.write('#define HAL_RAM_RESERVE_START 0x%08x\n' % ram_reserve_start)
@@ -1380,7 +1380,7 @@ class ChibiOSHWDef(object):
         if ext_flash_size > 32:
             self.error("We only support 24bit addressing over external flash")
 
-        ram_reserve_start,ram0_start_address = self.get_ram_reserve_start()
+        ram_reserve_start, ram0_start_address = self.get_ram_reserve_start()
         if ram_reserve_start > 0 and ram0_start_address == ram0_start:
             ram0_start += ram_reserve_start
             ram0_len -= ram_reserve_start
@@ -2403,17 +2403,25 @@ INCLUDE common.ld
                     (label, p.port, p.pin))
         f.write('\n')
 
+
     def bootloader_path(self):
         # always embed a bootloader if it is available
         this_dir = os.path.realpath(__file__)
         rootdir = os.path.relpath(os.path.join(this_dir, "../../../../.."))
         hwdef_dirname = os.path.basename(os.path.dirname(args.hwdef[0]))
+        # allow re-using of bootloader from different build:
+        use_bootloader_from_board = self.get_config('USE_BOOTLOADER_FROM_BOARD', default=None, required=False)
+        if use_bootloader_from_board is not None:
+            hwdef_dirname = use_bootloader_from_board
         bootloader_filename = "%s_bl.bin" % (hwdef_dirname,)
         bootloader_path = os.path.join(rootdir,
-                                       "Tools",
-                                       "bootloaders",
-                                       bootloader_filename)
-        return bootloader_path
+                                    "Tools",
+                                    "bootloaders",
+                                    bootloader_filename)
+        if os.path.exists(bootloader_path):
+            return os.path.realpath(bootloader_path)
+
+        return None
 
     def embed_bootloader(self, f):
         '''added bootloader to ROMFS'''


### PR DESCRIPTION
Tools : Squash all build support tools commits :

95fa2a5	Tools: fix handling of include files for Periph
 - This fix scans all the include files in a hwdef, not just one on the first line.
 - SW-159
 
1862b5d	chibios_hwdef.py: allow re-use of bootloader from other boards

633b415	Tools: add devid encode/decode
- This helps us better understand/maintain items in the parameter files.
- SW-159

356dcf6	Tools: add SITL defaults processor (partial)
 - Also added default files for Volanti
 - SW-241
 
 abeb3a3	waf: process Cx SITL defaults on configure (partial)
 - SW-241