### PR TITLE
AP_UAVCAN: upadte_rpm pass error_count

### DIFF
--- a/libraries/AP_UAVCAN/AP_UAVCAN.cpp
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.cpp
@@ -1075,7 +1075,7 @@ void AP_UAVCAN::handle_ESC_status(AP_UAVCAN* ap_uavcan, uint8_t node_id, const E
         .current = cb.msg->current,
     };
 
-    ap_uavcan->update_rpm(esc_index, cb.msg->rpm);
+    ap_uavcan->update_rpm(esc_index, cb.msg->rpm, cb.msg->error_count);
     ap_uavcan->update_telem_data(esc_index, t,
         AP_ESC_Telem_Backend::TelemetryType::CURRENT
             | AP_ESC_Telem_Backend::TelemetryType::VOLTAGE


### PR DESCRIPTION
To be able to log error_count we need to pass it in update_rpm function. 
Currawong ESC stores error information in escstatus->error_count 

SW-329