### PR TITLE
CxVersion: move include file to AP_FWVersion.h

### DIFF
--- a/libraries/AP_Common/AP_FWVersion.h
+++ b/libraries/AP_Common/AP_FWVersion.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL_Boards.h>
+#include <AP_Common/CxVersion.h>
 
 class PACKED AP_FWVersion {
 

--- a/libraries/AP_Common/AP_FWVersionDefine.h
+++ b/libraries/AP_Common/AP_FWVersionDefine.h
@@ -22,7 +22,6 @@
 
 #include <AP_Common/AP_FWVersion.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
-#include <AP_Common/CxVersion.h>
 
 /*
   allow vendors to set AP_CUSTOM_FIRMWARE_STRING in hwdef.dat


### PR DESCRIPTION
Previously LoggerMessageWriter wasn't correctly seeing that we had defined a custom fw string, so it was only logging our custom string message to the log, and leaving out the ArduPlane X.Y.Z string.

Relevant part of the code: https://github.com/CarbonixUAV/carbopilot_V2/blob/f40d82ea6de72052bcc94054b481e2c3930dccb1/libraries/AP_Logger/LoggerMessageWriter.cpp#L284-L296

Before:
CxPilot-7.0.0dev (F40D82EA)

After:
CxPilot-7.0.0dev (F40D82EA) [ArduPlane V4.5.6]"

Tested that plot.ardupilot.org now recognizes our logs as planes instead of quads.