### PR TITLE
CarbonixCommon: reduce AHRS_GPS_MINSATS

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/defaults.parm
@@ -1,5 +1,5 @@
 # Carbonix Common Defaults
-AHRS_GPS_MINSATS,20
+AHRS_GPS_MINSATS,6 # AHRS will estimate synthetic airspeed if GPS has at least this many satellites
 AHRS_GPS_USE,2
 ARMING_MIS_ITEMS,22
 ARMING_RUDDER,0


### PR DESCRIPTION
6 is the default value, we could delete this line instead, but in the
near-term, I want the comment to remain as a warning.