### PR TITLE
AP_Common: remove CxVersion stuff

### DIFF
--- a/.github/workflows/carbonix_build.yml
+++ b/.github/workflows/carbonix_build.yml
@@ -310,7 +310,7 @@ jobs:
       - name: Extract firmware version, commit id, and branch name
         id: extract_info
         run: |
-          FIRMWARE_VERSION=$(grep -oP '#define AP_CUSTOM_FIRMWARE_STRING "\K(.*)(?=")' libraries/AP_Common/CxVersion.h)
+          FIRMWARE_VERSION=$(grep -oP 'define AP_CUSTOM_FIRMWARE_STRING "\K(.*)(?=")' libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/version.inc)
           COMMIT_ID=$(git rev-parse --short HEAD)
           BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
           echo "firmware_version=$FIRMWARE_VERSION" >> $GITHUB_ENV

--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -44,7 +44,6 @@
 #include <SITL/SITL.h>
 #endif
 #include <AP_AHRS/AP_AHRS.h>
-#include <AP_Common/CxVersion.h>
 
 #ifdef HAL_PERIPH_ENABLE_RELAY
 #ifdef HAL_PERIPH_ENABLE_PWM_HARDPOINT

--- a/Tools/Carbonix_scripts/carbonix_waf_build.sh
+++ b/Tools/Carbonix_scripts/carbonix_waf_build.sh
@@ -9,7 +9,7 @@ echo "Running distclean..."
 main_boards=("CubeOrange" "CubeOrange-Volanti" "CubeOrange-Ottano")
 for board in "${main_boards[@]}"; do
   echo "Compiling ArduPlane for $board..."
-  ./waf configure --board "$board" --define=CARBOPILOT=1
+  ./waf configure --board "$board"
   ./waf plane
 done
 
@@ -29,7 +29,7 @@ for board in "${periph_boards[@]}"; do
     
     # Compile AP_Periph for each board
     echo "Compiling AP_Periph for $board with $filename..."
-    ./waf configure --board "$board" --define=CARBOPILOT=1 --extra-hwdef=temp.hwdef --default-parameters="$file"
+    ./waf configure --board "$board" --extra-hwdef=temp.hwdef --default-parameters="$file"
     ./waf AP_Periph
     
     # Rename build outputs
@@ -47,7 +47,7 @@ done
 # Build all Default periph board
 for board in "${periph_boards[@]}"; do
   echo "Compiling AP_Periph for $board..."
-  ./waf configure --board "$board" --define=CARBOPILOT=1
+  ./waf configure --board "$board"
   ./waf AP_Periph
 done
 

--- a/libraries/AP_Common/AP_FWVersion.h
+++ b/libraries/AP_Common/AP_FWVersion.h
@@ -3,7 +3,6 @@
 #include <stdint.h>
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL_Boards.h>
-#include <AP_Common/CxVersion.h>
 
 class PACKED AP_FWVersion {
 

--- a/libraries/AP_Common/CxVersion.h
+++ b/libraries/AP_Common/CxVersion.h
@@ -1,5 +1,0 @@
-#ifdef CARBOPILOT
-#ifndef AP_CUSTOM_FIRMWARE_STRING
-#define AP_CUSTOM_FIRMWARE_STRING "CxPilot-7.0.0dev"
-#endif
-#endif

--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/cubeorange.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/cubeorange.inc
@@ -2,6 +2,7 @@
 
 include ../CubeOrange/hwdef.dat
 include ./features.inc
+include ./version.inc
 
 # The Carbonix carrier board (CX13042008) uses uninverted logic for these pins,
 # as opposed to how the CubePilot carrier hardware is designed. We have to

--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/version.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/version.inc
@@ -1,0 +1,1 @@
+define AP_CUSTOM_FIRMWARE_STRING "CxPilot-7.0.0dev"

--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixF405/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixF405/hwdef.dat
@@ -1,3 +1,5 @@
+include ../CarbonixCommon/version.inc
+
 # hw definition file for processing by chibios_pins.py
 
 # MCU class and specific type


### PR DESCRIPTION
The way we embed CxPilot versioning could be better. The goals are:

- Get AP_CUSTOM_FIRMWARE_STRING defined in one file, that gets included everywhere, including SITL
Do so with the lowest merge-burden possible
- Originally, we had the version string in every hwdef. I tried moving it to a single hwdef include and having the SITL CI add the version as a commandline define, but that wasn’t working because I couldn’t get string defines to pass correctly.

This PR is much easier to rebase to future versions of ArduPilot, and it also means people don't have to remember to pass the "CARBOPILOT=1" when they build manually.