### PR TITLE
Tools: add -g to Carbonix Build Script

### DIFF
--- a/Tools/Carbonix_scripts/carbonix_waf_build.sh
+++ b/Tools/Carbonix_scripts/carbonix_waf_build.sh
@@ -9,7 +9,7 @@ echo "Running distclean..."
 main_boards=("CubeOrange" "CubeOrange-Volanti" "CubeOrange-Ottano")
 for board in "${main_boards[@]}"; do
   echo "Compiling ArduPlane for $board..."
-  ./waf configure --board "$board"
+  ./waf configure --board "$board" -g
   ./waf plane
 done
 
@@ -29,7 +29,7 @@ for board in "${periph_boards[@]}"; do
     
     # Compile AP_Periph for each board
     echo "Compiling AP_Periph for $board with $filename..."
-    ./waf configure --board "$board" --extra-hwdef=temp.hwdef --default-parameters="$file"
+    ./waf configure --board "$board" --extra-hwdef=temp.hwdef --default-parameters="$file" -g
     ./waf AP_Periph
     
     # Rename build outputs
@@ -47,7 +47,7 @@ done
 # Build all Default periph board
 for board in "${periph_boards[@]}"; do
   echo "Compiling AP_Periph for $board..."
-  ./waf configure --board "$board"
+  ./waf configure --board "$board" -g
   ./waf AP_Periph
 done
 


### PR DESCRIPTION
Enables debug symbols in the elf file. This does not impact the actual binary. Checked the build output of the carbonix waf script with winmerge; the elf files are the only things that change.

![image](https://github.com/user-attachments/assets/071727b0-aaa8-4b9c-8f57-22187824af68)

Here's an excel workbook with a report of the differences if you want to look yourself.
[compare.xlsx](https://github.com/user-attachments/files/17126993/compare.xlsx)

SW-382