### PR TITLE
hwdef: CarbonixCommon: disable stall prevention

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/defaults.parm
@@ -134,4 +134,5 @@ SERVO6_FUNCTION,19 # Elevator
 SERVO7_FUNCTION,0 # PLB Servo/GPIO
 SERVO8_FUNCTION,-1 # IGN relay GPIO
 SERVO9_FUNCTION,94 # Scripting function for LEDs
+STALL_PREVENTION,0 # Our high airspeed-min setting and QAssist should prevent bank-accelerated stalls
 TERRAIN_FOLLOW,72 # Enabled Auto and Guided (the command being executed must have the terrain frame though)


### PR DESCRIPTION
Let's validate this with a quick flight on Volanti before merging (Ottano shouldn't see much difference, since it cruises higher above min). Do some sharp-corner waypoint missions before and after this change.

SW-432