### PR TITLE
hwdef: CarbonixCommon: A7R1: del GPS_DRV_OPTIONS

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/payloads/A7R1/Cube.param
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/payloads/A7R1/Cube.param
@@ -1,4 +1,2 @@
-#File Details : ./Payload/A7R1/Cube.param, 8136862ae2560ff3efe2e54ff4447b23, CxPilot-5.1.3, 5118f344eb1777a8a4c33cf1b455be42b40dbeae
-GPS_DRV_OPTIONS,16
 SERVO14_FUNCTION,-1
 RELAY1_PIN,55

--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/payloads/A7R1/cpn_15(SerialGPS).parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/payloads/A7R1/cpn_15(SerialGPS).parm
@@ -1,2 +1,0 @@
-#File Details : ./Payload/A7R1/cpn_15(SerialGPS).parm, bec0e54ab38a90cbd892f6a0d0b50460, CxPilot-5.1.3, 5118f344eb1777a8a4c33cf1b455be42b40dbeae
-GPS_DRV_OPTIONS,16

--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/payloads/A7R1/cpn_19(DroneCANGPS).parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/payloads/A7R1/cpn_19(DroneCANGPS).parm
@@ -1,2 +1,0 @@
-#File Details : ./Payload/A7R1/cpn_19(DroneCANGPS).parm, bec0e54ab38a90cbd892f6a0d0b50460, CxPilot-5.1.3, 5118f344eb1777a8a4c33cf1b455be42b40dbeae
-GPS_DRV_OPTIONS,16

--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/payloads/A7R1/cpn_29(DroneCANGPS).parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/payloads/A7R1/cpn_29(DroneCANGPS).parm
@@ -1,2 +1,0 @@
-#File Details : ./Payload/A7R1/cpn_29(DroneCANGPS).parm, bec0e54ab38a90cbd892f6a0d0b50460, CxPilot-5.1.3, 5118f344eb1777a8a4c33cf1b455be42b40dbeae
-GPS_DRV_OPTIONS,16


### PR DESCRIPTION
We no longer need to log ellipsoidal height, as we're using an external PPK trigger logger.

SW-436