### PR TITLE
SITL : set ESC motor mask

### DIFF
--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -362,8 +362,8 @@ void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
     }
     
     // simulate engine RPM
-    motor_mask |= (1U<<2);
-    rpm[2] = thrust * 7000;
+    motor_mask |= (1U<<4);
+    rpm[4] = thrust * 7000;
     
     // scale thrust to newtons
     thrust *= thrust_scale;

--- a/libraries/SITL/SIM_QuadPlane.cpp
+++ b/libraries/SITL/SIM_QuadPlane.cpp
@@ -27,7 +27,7 @@ QuadPlane::QuadPlane(const char *frame_str) :
 {
     // default to X frame
     const char *frame_type = "x";
-    uint8_t motor_offset = 4;
+    uint8_t motor_offset = 0;
 
     ground_behavior = GROUND_BEHAVIOR_NO_MOVEMENT;
 


### PR DESCRIPTION
This is specific to Carbonix-Volanti.
This is useful during SITL testing for ESCs