### PR TITLE
CI: reenable test CANGPSCopterMission

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2856,7 +2856,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             # flying on DroneCAN ESCs
             "SIM_CAN_SRV_MSK" : 0xFF,
             # we can do the flight faster
-            "SIM_SPEEDUP" : 5,
+            "SIM_SPEEDUP" : 3,
         })
 
         self.CopterMission()

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -10831,7 +10831,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "GroundEffectCompensation_takeOffExpected": "Flapping",
             "GroundEffectCompensation_touchDownExpected": "Flapping",
             "FlyMissionTwice": "See https://github.com/ArduPilot/ardupilot/pull/18561",
-            "CANGPSCopterMission": "CX temporary : JIRA - SW-317"
         }
 
 


### PR DESCRIPTION
Now that the repo is public, this CI might pass. Never had it fail on a public repo, but almost always failed on this when private.