### PR TITLE
CX_BIT: remove unnecessary warnings before safety disengage

### DIFF
--- a/Tools/autotest/carbonix.py
+++ b/Tools/autotest/carbonix.py
@@ -91,6 +91,16 @@ class AutoTestCarbonix(AutoTestQuadPlane):
             # Confirm we didn't get lost/recovered/lost/recovered during that time
             self.assert_no_text(lost_text, timeout=1, regex=True, check_context=True)
 
+            # Engage the safety switch and trigger a telemetry failure, and
+            # confirm that we don't get the telemetry lost message
+            self.progress(f'Engaging safety switch and failing ESC telemetry for ESC {index}')
+            self.context_clear_collection('STATUSTEXT')
+            self.set_safetyswitch_on()
+            self.set_parameter('SIM_ESC_TLM_FAIL', 1 << index)
+            self.assert_no_text('^CX_BIT:.*', regex=True, check_context=True)
+            self.set_parameter('SIM_ESC_TLM_FAIL', 0)
+            self.set_safetyswitch_off()
+
             # And one more time, confirm no error messages are present
             self.context_clear_collection('STATUSTEXT')
             # TODO: clean this line up too when Servo Out nil is fixed

--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/scripts/modules/bit_esc.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/scripts/modules/bit_esc.lua
@@ -79,6 +79,21 @@ function ESC:esc_is_stopped(i)
 end
 
 function ESC:update()
+    -- When the safety is engaged, the ESCs do not output telemetry
+    if SRV_Channels:get_safety_state() then
+        -- Reset all the counters and flags
+        for i = 1, self.number_of_esc do
+            self.esc_warmup_end_time[i] = nil
+            self.srv_prv_telem_ms[i] = 0
+            self.srv_telem_in_err_status[i] = false
+            self.srv_rpm_in_err_status[i] = false
+            self.esc_rpm_nil_counter[i] = 0
+            self.servo_out_nil_counter[i] = 0
+        end
+        return
+    end
+
+    -- check for errors
     for i = 1, self.number_of_esc  do
         local esc_last_telem_data_ms = esc_telem:get_last_telem_data_ms(i-1):toint()
         local esc_rpm = esc_telem:get_rpm(i-1)


### PR DESCRIPTION
When the safety is engaged, the ESCs do not output telemetry. Since this is expected, the built-in-test should not warn the user.