### PR TITLE
CarbonixCommon: bit_esc: suppress nil warnings

### DIFF
--- a/Tools/autotest/carbonix.py
+++ b/Tools/autotest/carbonix.py
@@ -62,15 +62,7 @@ class AutoTestCarbonix(AutoTestQuadPlane):
             self.context_collect('STATUSTEXT')
             self.wait_ready_to_arm()
 
-            # Confirm no error messages are present, with one exception:
-            # "Servo Out nil" is not uncommon when running with simulation
-            # speedups. There is a race condition that can occur because
-            # SRV_Channels::function_mask gets periodically cleared and
-            # re-calculated.
-            # TODO: CX_BIT needs to switch to checking channel number instead
-            # of checking by function assignment, but that will take some work
-            # and will require a new binding.
-            self.assert_no_text('^CX_BIT:.*(?!Servo Out nil).*', regex=True, check_context=True)
+            self.assert_no_text('^CX_BIT:.*', regex=True, check_context=True)
 
             # Fail the ESC telemetry for the specified index
             self.progress(f'Failing ESC telemetry for ESC {index}')
@@ -93,8 +85,7 @@ class AutoTestCarbonix(AutoTestQuadPlane):
 
             # And one more time, confirm no error messages are present
             self.context_clear_collection('STATUSTEXT')
-            # TODO: clean this line up too when Servo Out nil is fixed
-            self.assert_no_text('^CX_BIT:.*(?!Servo Out nil).*', regex=True, check_context=True)
+            self.assert_no_text('^CX_BIT:.*', regex=True, check_context=True)
             self.context_pop()
 
         def TestMotorFail(esc_index, servo_index, is_pusher=False):

--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/scripts/modules/bit_esc.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/scripts/modules/bit_esc.lua
@@ -92,14 +92,14 @@ function ESC:update()
         -- Nil check for RPM reading
         elseif not esc_rpm then
             self.esc_rpm_nil_counter[i] = self.esc_rpm_nil_counter[i] + 1
-            if self.esc_rpm_nil_counter[i] > self.NIL_WARN_THRESHOLD and self.srv_rpm_in_err_status[i] == false then
+            if self.esc_rpm_nil_counter[i] >= self.NIL_WARN_THRESHOLD and self.srv_rpm_in_err_status[i] == false then
                 cx_msg:send(cx_msg.MAV_SEVERITY.CRITICAL, "ESC " .. i .. " Telemetry Lost")
                 self.srv_telem_in_err_status[i] = true
             end
         -- Nil check for servo output
         elseif not servo_out then
             self.servo_out_nil_counter[i] = self.servo_out_nil_counter[i] + 1
-            if self.servo_out_nil_counter[i] > self.NIL_WARN_THRESHOLD and self.srv_rpm_in_err_status[i] == false then
+            if self.servo_out_nil_counter[i] >= self.NIL_WARN_THRESHOLD and self.srv_rpm_in_err_status[i] == false then
                 cx_msg:send(cx_msg.MAV_SEVERITY.CRITICAL, "ESC " .. i .. " Telemetry Lost")
                 self.srv_telem_in_err_status[i] = true
             end

--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/scripts/modules/bit_esc.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/scripts/modules/bit_esc.lua
@@ -92,28 +92,24 @@ function ESC:update()
         -- Nil check for RPM reading
         elseif not esc_rpm then
             self.esc_rpm_nil_counter[i] = self.esc_rpm_nil_counter[i] + 1
-            if self.esc_rpm_nil_counter[i] < self.NIL_WARN_THRESHOLD then
-                cx_msg:send(cx_msg.MAV_SEVERITY.INFO, "ESC " .. i .. " RPM nil")
-            elseif self.srv_rpm_in_err_status[i] == false then
-                cx_msg:send(cx_msg.MAV_SEVERITY.CRITICAL, "ESC " .. i .. " RPM nil")
+            if self.esc_rpm_nil_counter[i] > self.NIL_WARN_THRESHOLD and self.srv_rpm_in_err_status[i] == false then
+                cx_msg:send(cx_msg.MAV_SEVERITY.CRITICAL, "ESC " .. i .. " Telemetry Lost")
                 self.srv_telem_in_err_status[i] = true
             end
         -- Nil check for servo output
         elseif not servo_out then
             self.servo_out_nil_counter[i] = self.servo_out_nil_counter[i] + 1
-            if self.servo_out_nil_counter[i] < self.NIL_WARN_THRESHOLD then
-                cx_msg:send(cx_msg.MAV_SEVERITY.INFO, "ESC " .. i .. " Servo Out nil")
-            elseif self.srv_rpm_in_err_status[i] == false then
-                cx_msg:send(cx_msg.MAV_SEVERITY.CRITICAL, "ESC " .. i .. " Servo Out nil")
+            if self.servo_out_nil_counter[i] > self.NIL_WARN_THRESHOLD and self.srv_rpm_in_err_status[i] == false then
+                cx_msg:send(cx_msg.MAV_SEVERITY.CRITICAL, "ESC " .. i .. " Telemetry Lost")
                 self.srv_telem_in_err_status[i] = true
             end
         -- Telemetry data is fresh and valid
         else
+            self.servo_out_nil_counter[i] = 0
+            self.esc_rpm_nil_counter[i] = 0
             if self.srv_telem_in_err_status[i] == true then
                 cx_msg:send(cx_msg.MAV_SEVERITY.INFO, "ESC " .. i .. " Telemetry Recovered")
                 self.srv_telem_in_err_status[i] = false
-                self.servo_out_nil_counter[i] = 0
-                self.esc_rpm_nil_counter[i] = 0
             end
             -- If armed, check that the motor is actually turning when it is commanded to
             if arming:is_armed() then


### PR DESCRIPTION
These are caused by two well-understood race conditions and we don't
need to put them up on the messages tab anymore. This will be fixed
properly in a future PR.

Also, driveby fix for resetting the nil counters. These should be done
every time we get good data, not just when recoving from telemetry loss.