### PR TITLE
CarbonixCommon: ottano-headless: cleanup comments

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/sitl_params/ottano-headless.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/sitl_params/ottano-headless.parm
@@ -69,8 +69,6 @@ RLL_RATE_P,0.141009
 RNGFND1_PIN,0
 RNGFND1_SCALING,40
 RNGFND1_TYPE,1
-# RPM1_SCALING,1.025 # Scaled up to match what we usually see on the Hirth
-# RPM1_TYPE,10 # SITL backend, our EFI lua script grabs its RPM from this sensor
 @delete SCR_*_CHECKSUM
 @delete SERIAL* # SITL does not need to replicate serial assignments
 @delete SERVO*


### PR DESCRIPTION
These two lines were commented out in some early testing and I missed
them when I originally committed this file.

I don't even have a ticket for this. Very low priority, but don't want to forget about it.

It's also not failing CI, I just cancelled the CarbonixBuild