### PR TITLE
Fix CX Build Compare CI 

### DIFF
--- a/.github/workflows/cx_build_compare.yml
+++ b/.github/workflows/cx_build_compare.yml
@@ -2,7 +2,7 @@ name: Compare Build Outputs
 
 on:
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, labeled]
 
 concurrency:
     group: ci-${{github.workflow}}-${{ github.ref }}
@@ -10,7 +10,7 @@ concurrency:
       
 jobs:
   build-and-compare:
-    if: github.event.label.name == 'CX_NO_CODE_CHANGE'
+    if: contains(github.event.pull_request.labels.*.name, 'CX_NO_CODE_CHANGE')
     runs-on: ubuntu-22.04
 
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.3

--- a/.github/workflows/cx_build_compare.yml
+++ b/.github/workflows/cx_build_compare.yml
@@ -52,6 +52,7 @@ jobs:
       
       - name: Check if Hwdef directory has been modified
         run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           git fetch origin ${{ github.event.pull_request.base.ref }}
           CHANGED=$(git diff --quiet HEAD origin/${{ github.event.pull_request.base.ref }} -- libraries/AP_HAL_ChibiOS/hwdef || echo "changed")
           if [ "$CHANGED" = "changed" ]; then
@@ -62,7 +63,6 @@ jobs:
       - name: Build Head and ${{ github.event.pull_request.base.ref }} ${{matrix.board}} 
         shell: bash
         run: |
-            git config --global --add safe.directory ${GITHUB_WORKSPACE}
             PATH="/github/home/.local/bin:$PATH"
 
             # export some environment variables designed to get


### PR DESCRIPTION
There 2 issues found.
- Safe directory initialisation was done one step later.
- This CI will only run when a label is attached and not when you push more code on top of it.