### PR TITLE
CarbonixCommon: add DroneCAN to default LED types

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/cx_cubecarrier.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/cx_cubecarrier.inc
@@ -15,3 +15,6 @@ define HAL_IMU_TEMP_DEFAULT 60
 
 # Set default airspeed type to DroneCAN
 define HAL_AIRSPEED_TYPE_DEFAULT TYPE_UAVCAN
+
+# Set default NTF_LED_TYPES to include DroneCAN
+define DEFAULT_NTF_LED_TYPES (Notify_LED_Board | I2C_LEDS | DRONECAN_LEDS)


### PR DESCRIPTION
I did this with a define in the hwdef instead of the param file. This has four advantages:
1. More readable. I am bitwise ORing groups of drivers by name. Better than a garbage number with a comment explaining what the bits are, which you have to independently verify.
2. Easier for future merges. If these defined groups change or grow upstream, I don't have to mess with my param value.
3. Saves a few bytes of flash (every byte I add to defaults.parm ends up taking space in flash).
4. I will eventually need to rebase #310 onto this PR, and it will be easier if I make the change here.

The downside is that it's slightly less intuitive to know where we're defining params. I save this only for when there is a good reason to put this in the hwdef (like the default airspeed sensor setting, which doesn't like being in defaults.parm). I think this is a good candidate too.