### PR TITLE
CarbonixCommon: add DroneCAN to default LED types

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/cx_cubecarrier.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/cx_cubecarrier.inc
@@ -15,3 +15,6 @@ define HAL_IMU_TEMP_DEFAULT 60
 
 # Set default airspeed type to DroneCAN
 define HAL_AIRSPEED_TYPE_DEFAULT TYPE_UAVCAN
+
+# Set default NTF_LED_TYPES to include DroneCAN
+define DEFAULT_NTF_LED_TYPES (Notify_LED_Board | I2C_LEDS | DRONECAN_LEDS)


### PR DESCRIPTION
Reopening of PR #312

Due to a misunderstanding of our branch protection rules (admins automatically bypass all rules by default, with no confirmation whatsoever; just an after-the-fact warning on the console), some commits errantly got pushed to CxPilot-7.

The previous version of this PR, got approved and merged on top of those commits, before we noticed what had happened. We went back and rewrote history on CxPilot-7 to fix the error (and fixed the branch protection rules), so I am reopening this PR to keep the commit-hash-to-PR links working.

The old CxPilot-7, before I cleaned it up force pushed, is preseved here: accidental-pushes-to-CxPilot-7