### PR TITLE
CX_BIT: Faster response for RPM DROP

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/scripts/modules/bit_esc.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CarbonixCommon/scripts/modules/bit_esc.lua
@@ -7,7 +7,7 @@ local ESC = {
     number_of_esc = 0,
 
     -- CONSTANTS
-    ESC_WARMUP_TIME = 3000,
+    ESC_WARMUP_TIME = 1000,
     ESC_RPM_THRESHOLD = 10,
     SERVO_OUT_THRESHOLD = 1010,
     -- wait 4 seconds after safety is engaged, to prevent ESC DROP messages
@@ -69,7 +69,7 @@ end
 
 -- Call this function whenever a motor starts running
 function ESC:esc_is_started(i)
-    -- Set the warm-up end time for this ESC to 3 seconds from now
+    -- Set the warm-up end time to ESC_WARMUP_TIME seconds from now
     self.esc_warmup_end_time[i] = millis() + self.ESC_WARMUP_TIME
 end
 


### PR DESCRIPTION
3 seconds is too long. Both Volanti and Ottano, based on a cursory review, reliably spin up in less than half a second. 1 second should be safe.