### PR TITLE
AP_Networking: make PPP much more robust

### DIFF
--- a/libraries/AP_Networking/AP_Networking.cpp
+++ b/libraries/AP_Networking/AP_Networking.cpp
@@ -89,7 +89,7 @@ const AP_Param::GroupInfo AP_Networking::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Networking options
     // @Description: Networking options
-    // @Bitmask: 0:EnablePPP Ethernet gateway
+    // @Bitmask: 0:EnablePPP Ethernet gateway, 5:DisablePPPTimeout, 6:DisablePPPEchoLimit
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 9,  AP_Networking,    param.options, 0),

--- a/libraries/AP_Networking/AP_Networking.h
+++ b/libraries/AP_Networking/AP_Networking.h
@@ -155,6 +155,8 @@ public:
 
     enum class OPTION {
         PPP_ETHERNET_GATEWAY=(1U<<0),
+        PPP_TIMEOUT_DISABLE=(1U<<5),
+        PPP_ECHO_LIMIT_DISABLE=(1U<<6),
     };
     bool option_is_set(OPTION option) const {
         return (param.options.get() & int32_t(option)) != 0;

--- a/libraries/AP_Networking/config/lwipopts.h
+++ b/libraries/AP_Networking/config/lwipopts.h
@@ -118,6 +118,12 @@ extern "C"
 
 #define USE_PPP 1
 
+// generate a regular LCP echo to keep link up
+#define LCP_ECHOINTERVAL                1
+
+// on 5 failed echos terminate link
+#define LCP_MAXECHOFAILS                5
+
 #define LWIP_TIMEVAL_PRIVATE 0
 #define LWIP_FD_SET_PRIVATE 0
 


### PR DESCRIPTION
Cherry-picked from a recent upstream PR that was emergency backported to 4.6.2 due to the risk of a watchdog.

It cherry-picked cleanly after I picked up Sid's PPP debugging commit. That debugging commit is a zero-compiler-output change, so it's perfectly safe to leave in here.

~~I recommend we delay this until I hear more about a potential regression that Tim found on one of his aircraft (though we should bench test in the meantime): https://discordapp.com/channels/674039678562861068/1387569695489789963~~

The watchdog event seems to only be a risk if using hardware flow control, which we aren't. Still, if we can get this in without performance issues then it's safer.