### PR TITLE
autotest: plane: fix LOITER_TURNS_zero_turn

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5372,8 +5372,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # Ensure we go back through this loiter point
         self.wait_distance_to_waypoint(3, distance_min=90, distance_max=110, timeout=90) # North West Loiter
 
-        self.wait_distance_to_waypoint(5, distance_min=10, distance_max=20, timeout=90)  # South West Waypoint
-        self.wait_distance_to_waypoint(6, distance_min=10, distance_max=20, timeout=90)  # South East Waypoint
+        self.wait_distance_to_waypoint(5, distance_min=10, distance_max=30, timeout=90)  # South West Waypoint
+        self.wait_distance_to_waypoint(6, distance_min=10, distance_max=30, timeout=90)  # South East Waypoint
 
         self.fly_home_land_and_disarm()
 


### PR DESCRIPTION
20m is too tight of a tolerance for the last two waypoints. Sometimes it misses that by a couple meters. Running locally, I could get this to fail every 2-3 times (my record was failing on the 7th). After this patch, I've run it 100 times straight with no issue.

Not sure why this only flaps on 4.5 and not on 4.7-dev or 4.6 (yet), but this fix works and should be totally safe.